### PR TITLE
node_modules/electron-to-chromium

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2173,9 +2173,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.370",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.370.tgz",
-      "integrity": "sha512-c+wzD4sCYQeNeasbnArwsU3ig6+lR6bwQmxfMjB6bx+XoopVSPFp+7ZLxqa90MTC+Tq9QQ5l7zsMNG9GgMBorg==",
+      "version": "1.4.371",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.371.tgz",
+      "integrity": "sha512-jlBzY4tFcJaiUjzhRTCWAqRvTO/fWzjA3Bls0mykzGZ7zvcMP7h05W6UcgzfT9Ca1SW2xyKDOFRyI0pQeRNZGw==",
       "dev": true
     },
     "node_modules/entities": {

--- a/src/index.html
+++ b/src/index.html
@@ -21,7 +21,6 @@
       href="https://uicdn.toast.com/tui.pagination/latest/tui-pagination.css"
     />
     <script src="https://uicdn.toast.com/tui.pagination/latest/tui-pagination.js"></script>    
-    ></script>
   </head>
   <body>
     <!-- W taki sposbu dodajemy fragmenty w główny HTML-plik strony. -->


### PR DESCRIPTION
przeprowadziłem proces naprawszy wg zaleceń mentora (usunięcie node-modules i package-lock.json) przeinstalowanie (npm i)  - gh-pages zwraca 404 więc może pomoże  -  bo poprawiło version dla electron-to-chromium
po ostatnich mergach w index.html została nadmiarowa "></script> co powodowało wyświetlanie się na samej górze ">"